### PR TITLE
SupplyFix

### DIFF
--- a/EngineHacks/SupplyFix.event
+++ b/EngineHacks/SupplyFix.event
@@ -1,0 +1,15 @@
+
+// removes hardcoded checks for chapter 5x (hopefully)
+// hack by stan
+
+PUSH
+
+    // do not display 0 gold in 5x
+    ORG $024DF2
+        SHORT $46C0 // nop
+
+    // allow convoy access in 5x
+    ORG $03164E
+        SHORT $E003 // b 0x08031658
+
+POP

--- a/EngineHacks/_MasterHackInstaller.event
+++ b/EngineHacks/_MasterHackInstaller.event
@@ -248,3 +248,5 @@ POP
 
   ALIGN 4
   #include "ExternalHacks/GroupAI/GroupAI.event"
+
+  #include "SupplyFix.event"


### PR DESCRIPTION
remove the hardcoding that prevents the supply from being accessed in ephraim's chapter (5x in vanilla)